### PR TITLE
Fixed bug that occurred when different branches had braids pointing to

### DIFF
--- a/lib/braid/mirror.rb
+++ b/lib/braid/mirror.rb
@@ -47,7 +47,7 @@ module Braid
         path = "vendor/plugins/#{path}"
       end
 
-      remote   = "braid/#{path}".gsub("_", '-') # stupid git svn changes all _ to ., weird
+      remote   = "#{branch}/braid/#{path}".gsub("_", '-') # stupid git svn changes all _ to ., weird
       squashed = !options["full"]
       branch = nil if type == "svn"
 
@@ -116,6 +116,14 @@ module Braid
 
     def cached_url
       git_cache.path(url)
+    end
+
+    def remote
+      if (attributes["remote"] && attributes["remote"] =~ /^braid\//)
+        attributes["remote"] = "#{branch}/#{attributes["remote"]}"
+      else
+        attributes["remote"]
+      end
     end
 
     private


### PR DESCRIPTION
different branches of the same repository.

Each branch of the target repository requires its own git remote.

Note the difference:
[remote "master/braid/xxx"]
    url = /Users/jd/.braid/cache/git_github.com__iteleport_xxx.git
    fetch =
+refs/heads/master:refs/remotes/master/braid/xxx/master
[remote "mybranch/braid/xxx"]
    url = /Users/jd/.braid/cache/git_github.com_iteleport_xxx.git
    fetch =
+refs/heads/mybranch:refs/remotes/mybranch/braid/xxx/mybranch
