### PR TITLE
correctly detect whether svn braid is up-to-date

### DIFF
--- a/lib/braid/commands/list.rb
+++ b/lib/braid/commands/list.rb
@@ -21,7 +21,7 @@ module Braid
           mirror.fetch
           new_revision    = validate_new_revision(mirror, options["revision"])
           target_revision = determine_target_revision(mirror, new_revision)
-          print " !!! UPDATE AVAILABLE !!!" if new_revision.to_s != mirror.base_revision.to_s
+          print " !!! UPDATE AVAILABLE !!!" if target_revision.to_s != mirror.base_revision.to_s
           print "\n"
         end
         print "\n"


### PR DESCRIPTION
Previously `braid list` would always show `UPDATE AVAILABLE` for any SVN
repository even if that local braid copy was completely up to date
w.r.t. the server.  The bug was caused by comparing SVN revision numbers
with git-svn commit hashes which would never compare equal.