### PR TITLE
Keep git fetch errors

### DIFF
--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -185,7 +185,7 @@ module Braid
       def fetch(remote = nil, *args)
         args.unshift "-n #{remote}" if remote
         # open4 messes with the pipes of index-pack
-        sh("git fetch #{args.join(' ')} 2>&1 > #{Gem.win_platform? ? 'nul' : '/dev/null'}")
+        sh("git fetch #{args.join(' ')} > #{Gem.win_platform? ? 'nul' : '/dev/null'}")
       end
 
       def checkout(treeish)


### PR DESCRIPTION
Currently fetch errors are discarded.  I found this while trying to clone a repo that doesn't have a HEAD.

Before:
$ braid add https://github.com/ansible/ansible.git src/ansible
Braid: Adding mirror of 'https://github.com/ansible/ansible.git'.
Braid: Setup: Creating remote for 'src/ansible'.
Braid: Resetting to '0a45227'.
Braid: Shell error: could not fetch

After:
$ braid add https://github.com/ansible/ansible.git src/ansible
Braid: Adding mirror of 'https://github.com/ansible/ansible.git'.
fatal: Couldn't find remote ref refs/heads/master
fatal: The remote end hung up unexpectedly
Braid: Resetting to '0a45227'.
Braid: Shell error: could not fetch

TODO: After this failure braid will fail like this:
$ braid add https://github.com/ansible/ansible.git src/ansible --branch=devel
Braid: Error: local changes are present