### PR TITLE
Tests: Set the committer identity per-repo, not globally.

### DIFF
--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -36,9 +36,9 @@ def create_git_repo_from_fixture(fixture_name)
   update_dir_from_fixture(fixture_name)
 
   in_dir(git_repo) do
-    run_command("git config --global --get user.email || git config --global user.email \"you@example.com\"")
-    run_command("git config --global --get user.name  || git config --global user.name \"Your Name\"")
     run_command('git init')
+    run_command("git config user.email \"you@example.com\"")
+    run_command("git config user.name \"Your Name\"")
     run_command('git add *')
     run_command("git commit -m \"initial commit of #{fixture_name}\"")
   end


### PR DESCRIPTION
In the VM I was using for Braid development, my global identity is
intentionally unset so that I'm prompted to choose an identity for each
repository.  Inasmuch as this is a valid use case, the test suite should
not change developers' global configuration without their consent.

We may as well set the identity unconditionally as a simplification.