### PR TITLE
Remove mentions of a changelog from CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,6 @@ Pester us if we don't get your Pull Requests merged in a timely fashion. :)
 
 ## How to speed the merging of pull requests
 
-* Describe your changes in the CHANGELOG.
-* Give yourself some credit in the appropriate place (usually the CHANGELOG).
 * Make commits of logical units.
 * Ensure your commit messages help others understand what you are doing and why.
 * Check for unnecessary whitespace with `git diff --check` before committing.


### PR DESCRIPTION
It doesn't appear that there has ever been a changelog.

If there is still a place where people are expected to give themselves credit (e.g., in the Contributors section of README.md), let me know or feel free to make the change yourself.