### PR TITLE
Print conflict messages for updates in squashed mode.

### DIFF
--- a/lib/braid/commands/update.rb
+++ b/lib/braid/commands/update.rb
@@ -75,6 +75,7 @@ module Braid
             git.merge_subtree(target_revision)
           end
         rescue Operations::MergeError => error
+          print error.conflicts_text
           msg 'Caught merge error. Breaking.'
         end
 


### PR DESCRIPTION
As discussed in https://github.com/cristibalan/braid/issues/41#issuecomment-275826716.

I was unable to get full-history mode to work at all, even in 1.0.3, in order to confirm how the feature should be implemented for that case:
```
$ braid add --full --revision=c10a6e92fa280a5613367e92eb47535479cee63d https://github.com/realityforge/buildr_plus.git vendor/tools/buildr_plus
Braid: Adding mirror of 'https://github.com/realityforge/buildr_plus.git' at 'c10a6e9'.
Braid: Resetting to '14154e5'.
Braid: Shell error: fatal: refusing to merge unrelated histories
```
@realityforge, does this work for you?