### PR TITLE
Resolve .git/MERGE_MSG correctly when using a linked working tree.

### DIFF
--- a/lib/braid/commands/update.rb
+++ b/lib/braid/commands/update.rb
@@ -86,7 +86,8 @@ module Braid
 
         commit_message = "Update mirror '#{mirror.path}' to #{display_revision(mirror)}"
         if in_error
-          File.open('.git/MERGE_MSG', 'w') { |f| f.puts(commit_message) }
+          merge_msg_path = git.repo_file_path('MERGE_MSG')
+          File.open(merge_msg_path, 'w') { |f| f.puts(commit_message) }
           return
         end
 

--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -161,6 +161,18 @@ module Braid
     end
 
     class Git < Proxy
+      # Get the physical path to a file in the git repository (e.g.,
+      # 'MERGE_MSG'), taking into account worktree configuration.  The returned
+      # path may be absolute or relative to the current working directory.
+      def repo_file_path(path)
+        if require_version('2.5')  # support for --git-path
+          invoke(:rev_parse, '--git-path', path)
+        else
+          # Git < 2.5 doesn't support linked worktrees anyway.
+          File.join(invoke(:rev_parse, '--git-dir'), path)
+        end
+      end
+
       def commit(message, *args)
         cmd = 'git commit --no-verify'
         if message # allow nil


### PR DESCRIPTION
Tested manually that the "braid update" I was trying to perform now
works.