### PR TITLE
Use Open3.capture3 to read stdout and stderr of subprocesses without deadlock.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 rvm:
   - 2.3.1
-  - 1.9.3
   - jruby-19mode
 addons:
   apt:

--- a/braid.gemspec
+++ b/braid.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |s|
   s.has_rdoc           = false
   s.rdoc_options       = %w(--line-numbers --inline-source --title braid --main)
 
+  s.required_ruby_version = '>= 2.2.0'
   s.add_dependency(%q<main>, ['>= 4.7.3'])
-  s.add_dependency(%q<open4>, ['>= 1.0.1']) unless defined?(JRUBY_VERSION)
 
   s.add_development_dependency(%q<rspec>, ['>= 3.4.4'])
   s.add_development_dependency(%q<mocha>, ['>= 0.9.11'])


### PR DESCRIPTION
Fixes #72.

I manually tested this using the test case in #72.  I don't think it's worth maintaining an automated test.  The existing test suite passes for me using Fedora's ruby-2.4.1-79.fc26.x86_64, JRuby-9.1.15.0 (upstream binary package), and RubyInstaller 2.5.0-1 on Windows.