### PR TITLE
get real commit id using rev-parse

### DIFF
--- a/lib/braid/command.rb
+++ b/lib/braid/command.rb
@@ -114,13 +114,13 @@ module Braid
       if mirror.tag
         if use_local_cache?
           Dir.chdir git_cache.path(mirror.url) do
-            git.rev_parse(mirror.local_ref)
+            git.rev_list_1(mirror.local_ref)
           end
         else
           raise BraidError, 'unable to retrieve tag version when cache disabled.'
         end
       else
-        git.rev_parse(mirror.local_ref)
+        git.rev_list_1(mirror.local_ref)
       end
     end
 
@@ -128,7 +128,7 @@ module Braid
       if revision.nil?
         determine_repository_revision(mirror)
       else
-        new_revision = git.rev_parse(revision)
+        new_revision = git.rev_list_1(revision)
 
         if new_revision == mirror.revision
           raise InvalidRevision, 'mirror is already at requested revision'

--- a/lib/braid/command.rb
+++ b/lib/braid/command.rb
@@ -114,13 +114,13 @@ module Braid
       if mirror.tag
         if use_local_cache?
           Dir.chdir git_cache.path(mirror.url) do
-            git.rev_list_1(mirror.local_ref)
+            git.rev_parse(mirror.local_ref + "^{commit}")
           end
         else
           raise BraidError, 'unable to retrieve tag version when cache disabled.'
         end
       else
-        git.rev_list_1(mirror.local_ref)
+        git.rev_parse(mirror.local_ref + "^{commit}")
       end
     end
 
@@ -128,7 +128,7 @@ module Braid
       if revision.nil?
         determine_repository_revision(mirror)
       else
-        new_revision = git.rev_list_1(revision)
+        new_revision = git.rev_parse(revision + "^{commit}")
 
         if new_revision == mirror.revision
           raise InvalidRevision, 'mirror is already at requested revision'

--- a/lib/braid/command.rb
+++ b/lib/braid/command.rb
@@ -114,6 +114,11 @@ module Braid
       if mirror.tag
         if use_local_cache?
           Dir.chdir git_cache.path(mirror.url) do
+            # Dereference the tag to a commit since we want the `revision`
+            # attribute of a mirror to always be a commit object.  This is also
+            # currently needed because we don't fetch annotated tags into the
+            # downstream repository, although we might change that in the
+            # future.
             git.rev_parse(mirror.local_ref + "^{commit}")
           end
         else

--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -223,14 +223,6 @@ module Braid
         raise UnknownRevision, opt
       end
 
-      # git rev-list -1 opt
-      def rev_list_1(opt)
-        opt.insert(0, '-1 ')
-        invoke(:rev_list, opt)
-      rescue ShellExecutionError
-        raise UnknownRevision, opt
-      end
-
       # Implies tracking.
       def remote_add(remote, path)
         invoke(:remote, 'add', remote, path)

--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -223,6 +223,14 @@ module Braid
         raise UnknownRevision, opt
       end
 
+      # git rev-list -1 opt
+      def rev_list_1(opt)
+        opt.insert(0, '-1 ')
+        invoke(:rev_list, opt)
+      rescue ShellExecutionError
+        raise UnknownRevision, opt
+      end
+
       # Implies tracking.
       def remote_add(remote, path)
         invoke(:remote, 'add', remote, path)

--- a/spec/integration/adding_spec.rb
+++ b/spec/integration/adding_spec.rb
@@ -138,6 +138,41 @@ describe 'Adding a mirror in a clean repository' do
     end
   end
 
+  describe 'from an annotated tag in a git repository' do
+    before do
+      @repository_dir = create_git_repo_from_fixture('shiny', :name => 'Some body', :email => 'somebody@example.com')
+      @vendor_repository_dir = create_git_repo_from_fixture('skit1')
+      in_dir(@vendor_repository_dir) do
+        run_command('git tag -a -m "v1" v1')
+      end
+
+      in_dir(@repository_dir) do
+        run_command("#{BRAID_BIN} add #{@vendor_repository_dir} --tag v1")
+      end
+    end
+
+    it 'should add the files and commit' do
+      assert_no_diff("#{FIXTURE_PATH}/skit1/layouts/layout.liquid", "#{@repository_dir}/skit1/layouts/layout.liquid")
+
+      in_dir(@repository_dir) do
+        assert_commit_subject(/Braid: Add mirror 'skit1' at '[0-9a-f]{7}'/)
+        assert_commit_author('Some body')
+        assert_commit_email('somebody@example.com')
+      end
+    end
+
+    it 'should create .braids.json and add the mirror to it' do
+      braids = YAML::load_file("#{@repository_dir}/.braids.json")
+      expect(braids['config_version']).to be_kind_of(Numeric)
+      mirror_obj = braids['mirrors']['skit1']
+      expect(mirror_obj['url']).to eq(@vendor_repository_dir)
+      expect(mirror_obj['revision']).not_to be_nil
+      expect(mirror_obj['branch']).to be_nil
+      expect(mirror_obj['tag']).to eq('v1')
+      expect(mirror_obj['path']).to be_nil
+    end
+  end
+
   describe 'from a revision in a git repository' do
     before do
       @repository_dir = create_git_repo_from_fixture('shiny', :name => 'Some body', :email => 'somebody@example.com')


### PR DESCRIPTION
references #78
with rev-parse you won't get the real commit id, e.g. when tag is annotated

maybe this is one possible solution. works with annotated tags (--tag) and with revisions (--revision).