### PR TITLE
Avoid LFS smudge/filter-process errors during the push operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
 Braid is a simple tool to help track vendor branches in a
 [Git](http://git-scm.com/) repository.
 
+## Fork motivation
+
+I tried to resolve an issue I had with **braid push**, because of Git LFS enabled on my repository.
+Also I want to keep my global Git configuration, having **git-lfs smuge** & **filter-process** on 
+
+    [filter "lfs"]
+        clean = git-lfs clean -- %f
+        smudge = git-lfs smudge -- %f
+        process = git-lfs filter-process
+        required = true
+
+The error I got was like that:
+
+    $ git-lfs.exe filter-process
+    Error downloading object: fileName : Smudge error: Error downloading fileName: batch request: missing protocol: ""
+
 ## Motivation
 
 Vendoring allows you take the source code of an external library and ensure it's

--- a/lib/braid/commands/push.rb
+++ b/lib/braid/commands/push.rb
@@ -58,6 +58,8 @@ module Braid
           git.config(['--local', 'user.name', "\"#{user_name}\""]) if user_name
           git.config(['--local', 'user.email', "\"#{user_email}\""]) if user_email
           git.config(['--local', 'commit.gpgsign', commit_gpgsign]) if commit_gpgsign
+		  git.config(['--local', 'filter.lfs.smudge', "\"git-lfs smudge --skip %f\"" ])
+          git.config(['--local', 'filter.lfs.process', "\"git-lfs filter-process --skip\""])
           # Adding other repositories as alternates is safe (we don't have to
           # worry about them being moved or deleted during the lifetime of this
           # temporary repository) and faster than fetching from them.  We don't


### PR DESCRIPTION
I tried to resolve an issue I had with **braid push**, because of Git LFS enabled on my repository.
Also I want to keep my global Git configuration, having **git-lfs smuge** & **filter-process** on 

    [filter "lfs"]
        clean = git-lfs clean -- %f
        smudge = git-lfs smudge -- %f
        process = git-lfs filter-process
        required = true

The error I got was like that:

    $ git-lfs.exe filter-process
    Error downloading object: fileName : Smudge error: Error downloading fileName: batch request: missing protocol: ""