### PR TITLE
Avoid pulling unnecessary blobs

### DIFF
--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -425,7 +425,7 @@ module Braid
           end
         else
           FileUtils.mkdir_p(local_cache_dir)
-          git.clone('--mirror', url, dir)
+          git.clone('--mirror', '--filter=blob:none', url, dir)
         end
       end
 


### PR DESCRIPTION
This will save a lot of disk and network space, and time when fetching the 1st time, mostly if your vendored repo is very big.