### PR TITLE
Test suite: Avoid changing the init.defaultBranch option globally.

### DIFF
--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -111,10 +111,13 @@ def create_git_repo_from_fixture(fixture_name, options = {})
   update_dir_from_fixture(directory, fixture_name)
 
   in_dir(git_repo) do
-    # Avoid a warning emitted by because we use the old default default branch name
-    run_command('git config --global init.defaultBranch master')
-
-    run_command('git init')
+    # If we don't specify the initial branch name, Git >= 2.30 warns that the
+    # default of `master` is subject to change.  We're still using `master` for
+    # now, so avoid the warning by specifying it explicitly.  Git >= 2.28 honors
+    # init.defaultBranch, while older versions of Git ignore it and are
+    # hard-coded to use `master`.  (Using the `--initial-branch=master` option
+    # would cause an error on Git < 2.28, so we don't do that.)
+    run_command('git -c init.defaultBranch=master init')
     run_command("git config --local user.email \"#{email}\"")
     run_command("git config --local user.name \"#{name}\"")
     run_command('git config --local commit.gpgsign false')

--- a/spec/integration/push_spec.rb
+++ b/spec/integration/push_spec.rb
@@ -342,9 +342,6 @@ describe 'Pushing to a mirror' do
       # the filter until after that step. :/
       @vendor_repository_dir = create_git_repo_from_fixture('skit1_with_filter')
 
-      # Avoid a warning emitted by because we use the old default default branch name
-      run_command('git config --global init.defaultBranch master')
-
       # Configure the broken filter globally.  Here, `false` is the command that
       # always exits 1.
       run_command('git config --global filter.broken.clean false')


### PR DESCRIPTION
We shouldn't change the developer's global configuration without their consent (or documenting that the test suite should always be run in an isolated environment of some kind).  See #37.

The full test suite passes on my Linux machine with Git 2.31.  I also tested a few cases on Linux with Git 2.27 and Git 2.28 and on Windows with Git 2.34; hopefully that's good enough because the full test suite is slow on my Windows machine.

This PR shouldn't need a new Braid release because it only affects the test suite.