### PR TITLE
Avoid `git read-tree --prefix=/`, which is rejected by Git >= 2.36.

### DIFF
--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -300,8 +300,10 @@ module Braid
             invoke(:checkout_index, path)
           end
         else
-          # Yes, if path == '', "git read-tree --prefix=/" works. :/
-          invoke(:read_tree, "--prefix=#{path}/", update_worktree ? '-u' : '-i', item)
+          # According to
+          # https://lore.kernel.org/git/e48a281a4d3db0a04c0609fcb8658e4fcc797210.1646166271.git.gitgitgadget@gmail.com/,
+          # `--prefix=` is valid if the path is empty.
+          res = invoke(:read_tree, "--prefix=#{path}", update_worktree ? '-u' : '-i', item)
         end
       end
 


### PR DESCRIPTION
Fixes #106.

It looks like the fix really is as simple as unconditionally removing the trailing slash.  I thought that something like `--prefix=dir` might naively prepend `dir` to filenames without inserting a slash, so a file named `foo` might end up at `dirfoo` instead of `dir/foo`, but I tested both the newest Git version as of this writing (2.36) and the oldest that Braid claims to support (2.3) and they both gave me `dir/foo`, so hopefully we're OK.  Maybe I was thinking of some other part of Git that does have that naive behavior.

If I leave out the `--prefix` option altogether when the path is empty as I originally suggested in https://github.com/cristibalan/braid/issues/106#issuecomment-1117409312, then I get an error: `-u is meaningless without -m, --reset, or --prefix`.  We could use `-m`, but that might risk behavior that is silently inconsistent with the case of a nonempty path.  I'd rather take the risk of `--prefix=` being rejected in the future, which I think is low.

The test suite passes on my Linux system with both Git 2.36 and Git 2.3 and on my Windows system with Git 2.36.  I can't think of a reasonable way to add a new test case for this fix; I think we should just rely on running the test suite with the newest released version of Git.