### PR TITLE
gemspec: Replace Git subprocess calls with hand-maintained file globs.

### DIFF
--- a/braid.gemspec
+++ b/braid.gemspec
@@ -16,9 +16,23 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project  = %q{braid}
 
-  s.files              = `git ls-files`.split("\n")
-  s.test_files         = `git ls-files -- {spec}/*`.split("\n")
-  s.executables        = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  # Recommendations on the web vary as to how to generate the `files` list.
+  # Bundler's template for new gems
+  # (https://github.com/rubygems/rubygems/blob/1e4eda741d732ca1bd7031aef0a16c7348adf7a5/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L25-L31)
+  # uses `git ls-files` in the hope of picking up all files that might be needed
+  # by the gem without picking up any garbage files.  However, running Git
+  # subprocesses here can be problematic in some contexts, including parts of
+  # the Braid test suite that set up a custom environment in which Git
+  # subprocesses invoked here would not work as intended
+  # (https://github.com/cristibalan/braid/issues/107).  So we use the other
+  # widely recommended approach of manually listing file globs
+  # (https://guides.rubygems.org/specification-reference/#files); this should be
+  # fine as long as we're careful to keep the list up to date.
+  #
+  # Ship only the files that are used at runtime, plus required legal notices.
+  # Users who want other files should use the source repository.
+  s.files              = ['LICENSE', 'bin/braid'] + Dir['lib/**/*.rb']
+  s.executables        = ['braid']
   s.require_paths      = %w(lib)
 
   s.rdoc_options       = %w(--line-numbers --inline-source --title braid --main)


### PR DESCRIPTION
This fixes an issue where custom Git environment variables intended for Git commands run on the user's repository affected these subprocesses as well and caused unintended behavior (https://github.com/cristibalan/braid/issues/107).

Also take the opportunity to cut back the files included in the packaged gem to those used at runtime plus required legal notices (currently, just LICENSE).  Just remove test_files: AFAICT, nothing uses it these days.

The test suite passed on my Linux and Windows machines.