### PR TITLE
Fix `braid diff` with multiple custom arguments.

### DIFF
--- a/lib/braid/commands/diff.rb
+++ b/lib/braid/commands/diff.rb
@@ -35,7 +35,7 @@ module Braid
 
         # XXX: Warn if the user specifies file paths that are outside the
         # mirror?  Currently, they just won't match anything.
-        git.diff_to_stdout(*mirror.diff_args(*options['git_diff_args']))
+        git.diff_to_stdout(*mirror.diff_args(options['git_diff_args']))
 
         clear_remote(mirror, options)
       end

--- a/lib/braid/mirror.rb
+++ b/lib/braid/mirror.rb
@@ -127,17 +127,7 @@ DESC
     # user-specified arguments.  Having the caller run "git diff" is convenient
     # for now but violates encapsulation a little; we may have to reorganize the
     # code in order to add features.
-    #
-    # FIXME: One call site in `braid diff` uses the `*` operator on the argument
-    # (i.e., `diff_args(*my_user_args)`), which gives a "wrong number of
-    # arguments" error if there's more than one argument.  We don't have a test
-    # case with more than one argument.  We do have a test case with one
-    # argument, but unfortunately, it didn't expose the bug because in Ruby, `*`
-    # of a non-list is a no-op, not an error.  However, when I specified the
-    # type of `user_args` as `T::Array[String]`, that test raised a runtime type
-    # check error, finally exposing the bug.  Fix the bug and then update the
-    # annotation here.  (The fix is trivial, but it needs a new test case...)
-    sig {params(user_args: T.untyped).returns(T::Array[String])}
+    sig {params(user_args: T::Array[String]).returns(T::Array[String])}
     def diff_args(user_args = [])
       upstream_item = upstream_item_for_revision(base_revision)
 

--- a/spec/integration/diff_spec.rb
+++ b/spec/integration/diff_spec.rb
@@ -224,6 +224,31 @@ index 9f75009..25a4b32 100644
 PATCH
       end
 
+      # A simple test of `braid diff` with more than one extra argument, which
+      # previously caused a crash.
+      it 'with the mirror specified and -R --cached should show only the staged uncommitted changes in reverse' do
+        diff = nil
+        in_dir(@repository_dir) do
+          diff = run_command("#{BRAID_BIN} diff skit1 -- -R --cached")
+        end
+
+        expect(diff).to eq(<<PATCH)
+diff --git b/layouts/layout.liquid a/layouts/layout.liquid
+index 25a4b32..9f75009 100644
+--- b/layouts/layout.liquid
++++ a/layouts/layout.liquid
+@@ -22,7 +22,7 @@
+ <![endif]-->
+ </head>
+ 
+-<body class="fixed green">
++<body class="fixed orange">
+ <script type="text/javascript">loadPreferences()</script>
+ 
+ <div id="wrapper">
+PATCH
+      end
+
       it 'without specifying a mirror and with --cached should show only the staged uncommitted changes with a banner' do
         diff = nil
         in_dir(@repository_dir) do


### PR DESCRIPTION
This fixes one of the bugs I found in #105.  The tests pass on my Linux and Windows systems.

This real (albeit minor) bug fix gives us an excuse to do a release.  That's probably a good thing to do anyway to get the infrastructure changes in #109 and #105 out to normal users.  Those changes weren't supposed to affect normal users, but if they cause an unexpected problem, it would be good to fix it soon rather than leaving it latent until the next release, which might be to fix an urgent bug.

@realityforge This seems like a good opportunity to ask: Now that you've decided I qualify as an "author" in the readme, would you be comfortable giving me the necessary privileges to do releases so that I could continue to maintain Braid if you're unavailable for any reason?  I made a RubyGems account with the username "mattmccutchen" (same as on GitHub).  I could do the release of this PR as "practice", or if you're worried about me messing it up, I could do a release under another gem name (e.g., `mattmccutchen-braid`) as practice.