### PR TITLE
Fix call to nonexistent `die` function.

### DIFF
--- a/lib/braid/command.rb
+++ b/lib/braid/command.rb
@@ -17,6 +17,11 @@ module Braid
       klass.new.run(*args)
 
     rescue BraidError => error
+      handle_error(error)
+    end
+
+    sig {params(error: BraidError).returns(T.noreturn)}
+    def self.handle_error(error)
       case error
         when Operations::ShellExecutionError
           msg "Shell error: #{error.message}"

--- a/lib/braid/main.rb
+++ b/lib/braid/main.rb
@@ -20,7 +20,8 @@ Main {
   # The "main" library doesn't provide a way to do this??
   def check_no_extra_args!
     if @argv.length > 0
-      die 'Extra argument(s) passed to command.'
+      Braid::Command.handle_error(
+        Braid::BraidError.new('Extra argument(s) passed to command.'))
     end
   end
 

--- a/lib/braid/sorbet/fake_runtime.rb
+++ b/lib/braid/sorbet/fake_runtime.rb
@@ -52,6 +52,9 @@ module Braid
     def self.untyped
       FAKE_TYPE
     end
+    def self.noreturn
+      FAKE_TYPE
+    end
     Boolean = FAKE_TYPE
     module Array
       def self.[](type)

--- a/spec/integration/adding_spec.rb
+++ b/spec/integration/adding_spec.rb
@@ -226,5 +226,14 @@ describe 'Adding a mirror in a clean repository' do
 
       expect(output).to match(/^Braid: Error: Can not add mirror specifying both a revision and a tag$/)
     end
+
+    it 'should generate an error if too many arguments are given' do
+      output = nil
+      in_dir(@repository_dir) do
+        output = `#{BRAID_BIN} add #{@vendor_repository_dir} skit1 extra`
+      end
+
+      expect(output).to eq("Braid: Error: Extra argument(s) passed to command.\n")
+    end
   end
 end


### PR DESCRIPTION
This fixes a regression from #105: oops.

I noticed the problem when I was working on bringing as many files as possible to `typed: true` and Sorbet reported an error on the call to `die`.  I guess I neglected to write a test case for this code path the first time around.  So the refactoring to set up the type checking infrastructure introduced a bug, which was caught by type checking, though unfortunately not until later.  I will save the `typed: true` changes for a later PR because they need some more work and may need more careful review; I wanted to get this (hopefully uncontroversial) regression fix out first.

The tests pass on my Linux and Windows systems.
