### PR TITLE
Get most files in `lib` to `typed: true` + other small changes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 # may be able to rely on it to pin the version instead.  Feel free to upgrade
 # Sorbet if you can fix any new type errors and the IDE features still seem to
 # work.
-SORBET_VERSION_SPEC = '= 0.5.9837'
+SORBET_VERSION_SPEC = '= 0.5.10101'
 
 # We want developers on OSes supported by `sorbet-static` to be able to get in
 # their bundle, but we also need to be able to run the test suite on OSes

--- a/braid.gemspec
+++ b/braid.gemspec
@@ -44,4 +44,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<mocha>, ['>= 0.9.11'])
   s.add_development_dependency(%q<rake>)
   s.add_development_dependency(%q<bundler>)
+  # Helpful for Braid developers to run `bundle exec irb` for manual testing of
+  # Braid internals.
+  s.add_development_dependency(%q<irb>)
 end

--- a/lib/braid/check_gem.rb
+++ b/lib/braid/check_gem.rb
@@ -1,3 +1,10 @@
+# Since this file can't safely depend on the Sorbet runtime, it isn't prudent to
+# try to commit to `typed: true` even if the file currently passes type checking
+# without needing any references to `T`.  Like `exe/braid`, this file doesn't
+# have much code worth type checking.
+#
+# typed: false
+
 # Braid has several entry points that run code from Ruby gems (either Braid
 # itself or dependencies such as Sorbet) and expect to get the correct versions
 # (either the same copy of Braid or versions of dependencies consistent with the

--- a/lib/braid/commands/add.rb
+++ b/lib/braid/commands/add.rb
@@ -1,3 +1,4 @@
+# typed: true
 module Braid
   module Commands
     class Add < Command

--- a/lib/braid/commands/diff.rb
+++ b/lib/braid/commands/diff.rb
@@ -1,3 +1,4 @@
+# typed: true
 module Braid
   module Commands
     class Diff < Command

--- a/lib/braid/commands/push.rb
+++ b/lib/braid/commands/push.rb
@@ -1,3 +1,4 @@
+# typed: true
 require 'fileutils'
 require 'tmpdir'
 

--- a/lib/braid/commands/remove.rb
+++ b/lib/braid/commands/remove.rb
@@ -1,3 +1,4 @@
+# typed: true
 module Braid
   module Commands
     class Remove < Command

--- a/lib/braid/commands/setup.rb
+++ b/lib/braid/commands/setup.rb
@@ -1,3 +1,4 @@
+# typed: true
 module Braid
   module Commands
     class Setup < Command

--- a/lib/braid/commands/status.rb
+++ b/lib/braid/commands/status.rb
@@ -1,3 +1,4 @@
+# typed: true
 module Braid
   module Commands
     class Status < Command

--- a/lib/braid/commands/update.rb
+++ b/lib/braid/commands/update.rb
@@ -1,3 +1,4 @@
+# typed: true
 module Braid
   module Commands
     class Update < Command

--- a/lib/braid/commands/upgrade_config.rb
+++ b/lib/braid/commands/upgrade_config.rb
@@ -1,3 +1,4 @@
+# typed: true
 module Braid
   module Commands
     class UpgradeConfig < Command

--- a/lib/braid/main.rb
+++ b/lib/braid/main.rb
@@ -1,13 +1,24 @@
+# typed: true
+
 require 'braid'
 
 require 'rubygems'
 require 'main'
 
+# This is needed for `T` below to resolve to `Braid::T` when using the fake
+# Sorbet runtime.  TODO: Indent the contents and accept the large diff?
+module Braid
+
 Home = File.expand_path(ENV['HOME'] || '~')
 
 # mostly blantantly stolen from ara's punch script
 # main kicks ass!
-Main {
+T.unsafe(Main).run {
+  # `Main` is somewhat mind-bending and I'm unsure what the type of `self`
+  # actually is here, but whatever it is, we don't have a type declaration for
+  # it.
+  T.bind(self, T.untyped)
+
   description <<-TXT
     braid is a simple tool to help track git repositories inside a git repository.
 
@@ -124,7 +135,7 @@ Main {
 
     mixin :optional_local_path, :option_verbose, :option_keep_remote
 
-    synopsis(Main::Usage.default_synopsis(self) + ' [-- git_diff_arg*]')
+    synopsis(T.unsafe(Main::Usage).default_synopsis(self) + ' [-- git_diff_arg*]')
 
     run {
       if @argv.length > 0 && @argv[0] == '--'
@@ -319,3 +330,5 @@ Main {
 
   run { help! }
 }
+
+end

--- a/lib/braid/sorbet/fake_runtime.rb
+++ b/lib/braid/sorbet/fake_runtime.rb
@@ -36,6 +36,10 @@ module Braid
     def self.must(value)
       value
     end
+    def self.unsafe(value)
+      value
+    end
+    def self.bind(value, type); end
 
     class FakeType
       include Singleton

--- a/lib/braid/version.rb
+++ b/lib/braid/version.rb
@@ -1,3 +1,6 @@
+# Ditto the comment in `check_gem.rb` regarding the `typed` sigil.
+# typed: false
+
 module Braid
   VERSION = '1.1.7'.freeze
 end


### PR DESCRIPTION
This PR contains some type checking work and a few other small changes that are independent but I thought would be more efficient to review and test in a single PR.  See the commit messages for details.

There's some arbitrariness to how I group the rest of the type checking changes into PRs.  @realityforge In general, do you prefer more, smaller PRs or fewer, larger PRs?  In this case, I thought it made sense to get the `typed: true` change out before I resume regular bug-fix and feature development because it will provide better type information in my IDE as I work.

The tests pass on my Linux and Windows systems.