### PR TITLE
braid add: Default to the remote default branch instead of `master`.

### DIFF
--- a/lib/braid.rb
+++ b/lib/braid.rb
@@ -12,14 +12,13 @@ module Braid
   # See the background in the "Supported environments" section of README.md.
   #
   # The newest Git feature that Braid is currently known to rely on is
-  # `receive.denyCurrentBranch = updateInstead` (in
-  # spec/integration/push_spec.rb), which was added in Git 2.3.0 (in 2015).  It
+  # `git ls-remote --symref`, which was added in Git 2.8.0 (in 2016).  It
   # doesn't seem worth even a small amount of work to remove that dependency and
   # support even older versions of Git.  So set that as the declared requirement
   # for now.  In general, a reasonable approach might be to try to support the
   # oldest version of Git in current "long-term support" versions of popular OS
   # distributions.
-  REQUIRED_GIT_VERSION = '2.3.0'
+  REQUIRED_GIT_VERSION = '2.8.0'
 
   @verbose = T.let(false, T::Boolean)
 

--- a/lib/braid/commands/add.rb
+++ b/lib/braid/commands/add.rb
@@ -2,15 +2,54 @@
 module Braid
   module Commands
     class Add < Command
+      # Returns the default branch name of the repository at the given URL, or
+      # nil if it couldn't be determined.
+      #
+      # We won't be able to determine a default branch in certain cases that we
+      # expect to be unusual in the context of Braid, such as if the HEAD is
+      # detached or points to a ref outside of `refs/heads`.  (Presumably, the
+      # same thing happens if the server is too old to report symrefs to us.)
+      # In those cases, a plausible alternative behavior would be to just lock
+      # the mirror to the remote HEAD revision, but that's probably not what the
+      # user wants.  It's much more likely that something is wrong and Braid
+      # should report an error.
+      def get_default_branch_name(url)
+        head_targets = []
+        # The `HEAD` parameter here doesn't appear to do an exact match (it
+        # appears to match any ref with `HEAD` as the last path component, such
+        # as `refs/remotes/origin/HEAD` in the unusual case where the repository
+        # contains its own remote-tracking branches), but it reduces the data we
+        # have to scan a bit.
+        git.ls_remote('--symref', url, 'HEAD').split("\n").each do |line|
+          m = /^ref: (.*)\tHEAD$/.match(line)
+          head_targets.push(m[1]) if m
+        end
+        return nil unless head_targets.size == 1
+        m = /^refs\/heads\/(.*)$/.match(head_targets[0])
+        return nil unless m
+        m[1]
+      end
+
       def run(url, options = {})
         with_reset_on_error do
+          if options['branch'].nil? && options['tag'].nil? && options['revision'].nil?
+            default_branch = get_default_branch_name(url)
+            if default_branch.nil?
+              raise BraidError, <<-MSG
+Failed to detect the default branch of the remote repository.  Please specify
+the branch you want to use via the --branch option.
+MSG
+            end
+            options['branch'] = default_branch
+          end
+
           mirror           = config.add_from_options(url, options)
           add_config_file
 
           mirror.branch = nil if options['revision']
           raise BraidError, 'Can not add mirror specifying both a revision and a tag' if options['revision'] && mirror.tag
 
-          branch_message   = (mirror.branch.nil? || mirror.branch == 'master') ? '' : " branch '#{mirror.branch}'"
+          branch_message   = mirror.branch.nil? ? '' : " branch '#{mirror.branch}'"
           tag_message      = mirror.tag.nil? ? '' : " tag '#{mirror.tag}'"
           revision_message = options['revision'] ? " at #{display_revision(mirror, options['revision'])}" : ''
           msg "Adding mirror of '#{mirror.url}'#{branch_message}#{tag_message}#{revision_message}."

--- a/lib/braid/mirror.rb
+++ b/lib/braid/mirror.rb
@@ -86,7 +86,7 @@ DESC
       raise NoTagAndBranch if options['tag'] && options['branch']
 
       tag = options['tag']
-      branch = options['branch'] || (tag.nil? ? 'master' : nil)
+      branch = options['branch']
 
       path = (options['path'] || extract_path_from_url(url, options['remote_path'])).sub(/\/$/, '')
       raise PathRequired unless path

--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -143,12 +143,7 @@ module Braid
       # 'MERGE_MSG'), taking into account worktree configuration.  The returned
       # path may be absolute or relative to the current working directory.
       def repo_file_path(path)
-        if require_version('2.5')  # support for --git-path
-          invoke(:rev_parse, '--git-path', path)
-        else
-          # Git < 2.5 doesn't support linked worktrees anyway.
-          File.join(invoke(:rev_parse, '--git-dir'), path)
-        end
+        invoke(:rev_parse, '--git-path', path)
       end
 
       # If the current directory is not inside a git repository at all, this
@@ -298,9 +293,7 @@ module Braid
       # file).
       def add_item_to_index(item, path, update_worktree)
         if item.is_a?(BlobWithMode)
-          # Our minimum git version is 1.6.0 and the new --cacheinfo syntax
-          # wasn't added until 2.0.0.
-          invoke(:update_index, '--add', '--cacheinfo', item.mode, item.hash, path)
+          invoke(:update_index, '--add', '--cacheinfo', "#{item.mode},#{item.hash},#{path}")
           if update_worktree
             # XXX If this fails, we've already updated the index.
             invoke(:checkout_index, path)

--- a/spec/integration/adding_spec.rb
+++ b/spec/integration/adding_spec.rb
@@ -39,6 +39,60 @@ describe 'Adding a mirror in a clean repository' do
     end
   end
 
+  describe 'from a git repository with a different default branch name' do
+    before do
+      @repository_dir = create_git_repo_from_fixture('shiny', :name => 'Some body', :email => 'somebody@example.com')
+      @vendor_repository_dir = create_git_repo_from_fixture('skit1')
+      in_dir(@vendor_repository_dir) do
+        run_command('git branch -m main')
+      end
+
+      in_dir(@repository_dir) do
+        run_command("#{BRAID_BIN} add #{@vendor_repository_dir}")
+      end
+    end
+
+    it 'should add the files and commit' do
+      assert_no_diff("#{FIXTURE_PATH}/skit1/layouts/layout.liquid", "#{@repository_dir}/skit1/layouts/layout.liquid")
+
+      in_dir(@repository_dir) do
+        assert_commit_subject(/Braid: Add mirror 'skit1' at '[0-9a-f]{7}'/)
+        assert_commit_author('Some body')
+        assert_commit_email('somebody@example.com')
+      end
+    end
+
+    it 'should create .braids.json and add the mirror to it' do
+      braids = YAML::load_file("#{@repository_dir}/.braids.json")
+      expect(braids['config_version']).to be_kind_of(Numeric)
+      mirror_obj = braids['mirrors']['skit1']
+      expect(mirror_obj['url']).to eq(@vendor_repository_dir)
+      expect(mirror_obj['revision']).not_to be_nil
+      expect(mirror_obj['branch']).to eq('main')
+      expect(mirror_obj['tag']).to be_nil
+      expect(mirror_obj['path']).to be_nil
+    end
+  end
+
+  describe 'from a git repository with a detached HEAD' do
+    before do
+      @repository_dir = create_git_repo_from_fixture('shiny', :name => 'Some body', :email => 'somebody@example.com')
+      @vendor_repository_dir = create_git_repo_from_fixture('skit1')
+      in_dir(@vendor_repository_dir) do
+        run_command('git checkout --quiet HEAD^{commit}')
+      end
+    end
+
+    it 'should generate an error that the default branch cannot be detected' do
+      output = nil
+      in_dir(@repository_dir) do
+        output = `#{BRAID_BIN} add #{@vendor_repository_dir}`
+      end
+
+      expect(output).to match(/^Braid: Error: Failed to detect the default branch/)
+    end
+  end
+
   describe 'from a subdirectory in a git repository' do
     before do
       @repository_dir = create_git_repo_from_fixture('shiny', :name => 'Some body', :email => 'somebody@example.com')

--- a/spec/mirror_spec.rb
+++ b/spec/mirror_spec.rb
@@ -1,11 +1,6 @@
 require File.dirname(__FILE__) + '/test_helper'
 
 describe 'Braid::Mirror.new_from_options' do
-  it 'should default branch to master' do
-    new_from_options('git://path')
-    expect(@mirror.branch).to eq('master')
-  end
-
   it 'should default mirror to last path part, ignoring trailing .git' do
     new_from_options('http://path.git')
     expect(@mirror.path).to eq('path')
@@ -14,11 +9,6 @@ describe 'Braid::Mirror.new_from_options' do
   it 'should strip trailing slash from specified path' do
     new_from_options('http://path.git', 'path' => 'vendor/tools/mytool/')
     expect(@mirror.path).to eq('vendor/tools/mytool')
-  end
-
-  it 'should define local_ref correctly when default branch specified' do
-    new_from_options('http://mytool.git')
-    expect(@mirror.local_ref).to eq('master/braid/mytool/master')
   end
 
   it 'should define local_ref correctly when explicit branch specified' do
@@ -37,11 +27,6 @@ describe 'Braid::Mirror.new_from_options' do
     }.to raise_error(Braid::Mirror::NoTagAndBranch)
   end
 
-  it 'should define remote_ref correctly when default branch specified' do
-    new_from_options('http://mytool.git')
-    expect(@mirror.remote_ref).to eq('+refs/heads/master')
-  end
-
   it 'should define remote_ref correctly when explicit branch specified' do
     new_from_options('http://mytool.git', 'branch' => 'mybranch')
     expect(@mirror.remote_ref).to eq('+refs/heads/mybranch')
@@ -50,11 +35,6 @@ describe 'Braid::Mirror.new_from_options' do
   it 'should define remote_ref correctly when explicit tag specified' do
     new_from_options('http://mytool.git', 'tag' => 'v1')
     expect(@mirror.remote_ref).to eq('+refs/tags/v1')
-  end
-
-  it 'should define remote correctly when default branch specified' do
-    new_from_options('http://mytool.git')
-    expect(@mirror.remote).to eq('master/braid/mytool')
   end
 
   it 'should define remote correctly when explicit branch specified' do
@@ -68,7 +48,7 @@ describe 'Braid::Mirror.new_from_options' do
   end
 
   it 'should strip first dot from remote path for dot files and folders' do
-    new_from_options('http://path.git', 'path' => '.dotfolder/.dotfile.ext')
+    new_from_options('http://path.git', 'branch' => 'master', 'path' => '.dotfolder/.dotfile.ext')
     expect(@mirror.path).to eq('.dotfolder/.dotfile.ext')
     expect(@mirror.remote).to eq('master/braid/_dotfolder/_dotfile.ext')
   end


### PR DESCRIPTION
- Raise the required Git version to 2.8 so we can use `git ls-remote --symref`.  Clean up one code path for old Git versions that is now obsolete as well as another I noticed that was already obsolete.

- Previously, the output of `braid add` omitted the branch name if it was `master`.  I don't think it's worth trying to update this special code path to check against the remote default branch instead, so I'm just removing it and showing the branch name unconditionally.  It doesn't seem too ugly to me, and some users may even find it helpful.

---

Fixes #87.  The tests pass on my Linux and Windows systems.

I removed the code path in `mirror.rb` that implicitly sets the branch to `master` since `add.rb` is now responsible for passing in the correct branch name, whatever it is.  I hope that doesn't cause any unexpected behavior elsewhere in Braid.  It did cause some unit tests to fail.  For most of the failing tests, I didn't have a good idea of how to update them so they would still have value, so I just deleted them.  @realityforge Do you have a better idea?

I realize that in general, I've been letting many of the unit tests decay over time because for most Braid features, I think integration testing is a more useful approach: it's capable of catching a wider range of problems, and the tests don't have to be updated as often in response to internal changes.  I know some people are passionately in favor of unit testing over integration testing, but I'm not familiar with all the arguments they make or whether I would be persuaded by those arguments in the context of Braid.  One annoying thing about the integration tests is that they're slow, especially on my Windows machine, but I can live with that and maybe get a faster machine, and there may be some relatively easy changes we can make to speed up the integration tests somewhat if we want.

I think we should make a release after this PR is merged, and I'll be happy to do it myself.