### PR TITLE
Show full stderr of failed commands + various maintenance 2024-08-02

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 # may be able to rely on it to pin the version instead.  Feel free to upgrade
 # Sorbet if you can fix any new type errors and the IDE features still seem to
 # work.
-SORBET_VERSION_SPEC = '= 0.5.10101'
+SORBET_VERSION_SPEC = '= 0.5.11504'
 
 # We want developers on OSes supported by `sorbet-static` to be able to get in
 # their bundle, but we also need to be able to run the test suite on OSes

--- a/development.md
+++ b/development.md
@@ -10,10 +10,8 @@ code are annotated so far, but we are already seeing maintainability benefits
 for those parts.
 
 **Regarding IDE support:** Sorbet provides [an
-extension](https://sorbet.org/docs/vscode) for Visual Studio Code.  If you use
-VSCodium, the extension is not available in Open VSX as of this writing
-(2022-03-20), but it's easy enough to build and install from
-[source](https://github.com/sorbet/sorbet/tree/master/vscode_extension).  In
+extension](https://sorbet.org/docs/vscode) for Visual Studio Code.  The
+extension is also available in Open VSX for VSCodium users.  In
 theory, it should be possible to use the Sorbet language server with another
 IDE, but we haven't researched this.
 

--- a/development.md
+++ b/development.md
@@ -70,3 +70,26 @@ system, and consider contributing a fix.  If `sorbet-static` is not installed,
 you won't be able to use its static type checking and code navigation
 functionality.  However, `sorbet-runtime` works the same way on all operating
 systems (when Braid is configured to use it as described above).
+
+## Matt's checklist for validating a change to Braid
+
+This is not an official policy at this point, but I thought I would go ahead and
+make it public in case anyone else wants to use it.
+
+TODO: Running all these steps is a big hassle.  Automate it better?
+
+- `bundle exec rake` in my regular development environment on Linux: runs the
+  test suite with the real Sorbet runtime, plus type checking and packaging.
+
+- `BRAID_USE_SORBET_RUNTIME=0 bundle exec rake spec` to catch missing
+  functionality in the fake Sorbet runtime.
+
+- `bundle exec rake spec` with the oldest version of Git that Braid claims to
+  support (`REQUIRED_GIT_VERSION`) added to `$PATH`.
+
+- `bundle exec rake spec` with Git built from the upstream `next` branch added
+  to `$PATH`.  This helps catch upcoming incompatibilities a little sooner.
+
+- `bundle exec rake spec` in my Windows VM.
+
+- Ask Peter to test on macOS as desired.

--- a/lib/braid.rb
+++ b/lib/braid.rb
@@ -59,11 +59,6 @@ module Braid
 
   class BraidError < StandardError
     extend T::Sig
-    sig {returns(String)}
-    def message
-      value = super
-      value if value != self.class.name
-    end
   end
 
   class InternalError < BraidError

--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -21,14 +21,7 @@ module Braid
 
       sig {returns(String)}
       def message
-        first_line = @err.to_s.split("\n").first
-        # Currently, first_line can be nil if @err was empty, but Sorbet thinks
-        # that the `message` method of an Exception should always return non-nil
-        # (although override checking isn't enforced as of this writing), so
-        # handle nil here.  This seems ad-hoc but better than putting in a
-        # `T.must` that we know has a risk of being wrong.  Hopefully this will
-        # be fixed better in https://github.com/cristibalan/braid/issues/90.
-        first_line.nil? ? '' : first_line
+        @err
       end
     end
     class VersionTooLow < BraidError

--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -10,12 +10,11 @@ module Braid
 
   module Operations
     class ShellExecutionError < BraidError
-      # TODO (typing): Should this be nilable?
-      sig {returns(T.nilable(String))}
+      sig {returns(String)}
       attr_reader :err, :out
 
-      sig {params(err: T.nilable(String), out: T.nilable(String)).void}
-      def initialize(err = nil, out = nil)
+      sig {params(err: String, out: String).void}
+      def initialize(err, out)
         @err = err
         @out = out
       end
@@ -252,7 +251,7 @@ module Braid
         elsif out.match(/nothing.* to commit/)
           false
         else
-          raise ShellExecutionError, err
+          raise ShellExecutionError.new(err, out)
         end
       end
 
@@ -364,7 +363,7 @@ module Braid
             # This can happen if the user runs `braid add` with a `--path` that
             # doesn't exist.  TODO: Make the error message more user-friendly in
             # that case.
-            raise ShellExecutionError, 'No tree item exists at the given path'
+            raise BraidError, 'No tree item exists at the given path'
           end
           mode = T.must(m[1])
           type = T.must(m[2])
@@ -374,7 +373,7 @@ module Braid
           elsif type == 'blob'
             return BlobWithMode.new(hash, mode)
           else
-            raise ShellExecutionError, 'Tree item is not a tree or a blob'
+            raise BraidError, 'Tree item is not a tree or a blob'
           end
         end
       end

--- a/spec/integration/adding_spec.rb
+++ b/spec/integration/adding_spec.rb
@@ -125,6 +125,21 @@ describe 'Adding a mirror in a clean repository' do
     end
   end
 
+  describe 'from a nonexistent git repository' do
+    # In general, Braid should show the full stderr of a failed command
+    # (https://github.com/cristibalan/braid/issues/90).  Adding a nonexistent
+    # repository is a convenient way to test the general behavior.
+    it 'should show the full stderr of the failed command' do
+      @repository_dir = create_git_repo_from_fixture('shiny', :name => 'Some body', :email => 'somebody@example.com')
+      @vendor_repository_dir = File.join(TMP_PATH, 'nonexistent')
+
+      in_dir(@repository_dir) do
+        output = run_command_expect_failure("#{BRAID_BIN} add #{@vendor_repository_dir}")
+        expect(output).to match(/Please make sure you have the correct access rights/)
+      end
+    end
+  end
+
   describe 'from a nonexistent subdirectory in a git repository' do
     it 'should print a meaningful error message' do
       @repository_dir = create_git_repo_from_fixture('shiny', :name => 'Some body', :email => 'somebody@example.com')

--- a/spec/integration/config_versioning_spec.rb
+++ b/spec/integration/config_versioning_spec.rb
@@ -106,7 +106,7 @@ describe 'Config versioning:' do
         output = run_command("#{BRAID_BIN} upgrade-config")
         # Check this on one of the test cases.
         expect(output).to match(/Configuration upgrade complete\./)
-        expect(File.exists?('.braids')).to eq(false)
+        expect(File.exist?('.braids')).to eq(false)
         assert_no_diff_in_braids('.braids.json', 'expected.braids.json')
       end
     end
@@ -116,7 +116,7 @@ describe 'Config versioning:' do
 
       in_dir(@repository_dir) do
         run_command("#{BRAID_BIN} upgrade-config")
-        expect(File.exists?('.braids')).to eq(false)
+        expect(File.exist?('.braids')).to eq(false)
         assert_no_diff_in_braids('.braids.json', 'expected.braids.json')
       end
     end
@@ -153,7 +153,7 @@ describe 'Config versioning:' do
         expect(output).to match(/skit1.*full-history/)
         expect(output).to match(/Run 'braid upgrade-config --allow-breaking-changes'/)
         assert_no_diff('.braids', "#{FIXTURE_PATH}/shiny-conf-breaking-changes/.braids")
-        expect(File.exists?('.braids.json')).to eq(false)
+        expect(File.exist?('.braids.json')).to eq(false)
       end
     end
 
@@ -168,7 +168,7 @@ describe 'Config versioning:' do
         expect(output).to match(/You must pass --allow-breaking-changes/)
         # `braid upgrade-config` should not have changed any files.
         assert_no_diff('.braids', "#{FIXTURE_PATH}/shiny-conf-breaking-changes/.braids")
-        expect(File.exists?('.braids.json')).to eq(false)
+        expect(File.exist?('.braids.json')).to eq(false)
       end
     end
 
@@ -181,7 +181,7 @@ describe 'Config versioning:' do
         expect(output).to match(/Spoon-Knife.*Subversion/)
         expect(output).to match(/skit1.*full-history/)
         expect(output).to match(/Configuration upgrade complete\./)
-        expect(File.exists?('.braids')).to eq(false)
+        expect(File.exist?('.braids')).to eq(false)
         assert_no_diff_in_braids('.braids.json', 'expected.braids.json')
       end
     end
@@ -213,7 +213,7 @@ describe 'Config versioning:' do
       in_dir(@repository_dir) do
         output = run_command("#{BRAID_BIN} upgrade-config")
         expect(output).to match(/has no Braid configuration file/)
-        expect(File.exists?('.braids.json')).to eq(false)
+        expect(File.exist?('.braids.json')).to eq(false)
       end
     end
 


### PR DESCRIPTION
This PR makes Braid show the full stderr of a ShellExecutionError when a command fails (fixing #90).  I've bundled several less interesting maintenance changes into the same PR to reduce the overhead of running tests; the changes are still in separate commits for ease of review.  Hopefully most of these are uncontroversial.  I'm open to opinions about whether it's a good idea to add my testing checklist in its current form.

The tests pass on my Linux and Windows systems.  @realityforge If you want to continue to support macOS, please run the tests and also check that the Sorbet static analyzer still works; `bundle exec rake` should take care of both of those things.  You may have to update the RUBY_PLATFORM check in the Gemfile to match your current macOS environment.

It's been a long time and I had a bunch of challenges in life, but things finally aligned for me to finalize this relatively small change.  I'm hoping I will keep the momentum and finish some bigger things soon, like the type annotations.  Cheers!