### PR TITLE
Finish first pass of type annotations for `lib` + other small changes.

### DIFF
--- a/braid.gemspec
+++ b/braid.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.rdoc_options       = %w(--line-numbers --inline-source --title braid --main)
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.add_dependency(%q<main>, ['>= 4.7.3'])
   # XXX: Minimum version?
   s.add_dependency(%q<json>)

--- a/development.md
+++ b/development.md
@@ -9,6 +9,8 @@ static type checking and code navigation in compatible IDEs.  Only parts of the
 code are annotated so far, but we are already seeing maintainability benefits
 for those parts.
 
+### Structure of the tools
+
 **Regarding IDE support:** Sorbet provides [an
 extension](https://sorbet.org/docs/vscode) for Visual Studio Code.  The
 extension is also available in Open VSX for VSCodium users.  In
@@ -70,6 +72,17 @@ system, and consider contributing a fix.  If `sorbet-static` is not installed,
 you won't be able to use its static type checking and code navigation
 functionality.  However, `sorbet-runtime` works the same way on all operating
 systems (when Braid is configured to use it as described above).
+
+### Issues we've run into
+
+- If you initialize a variable to `[]` or `{}` and then add items to it, Sorbet
+  may not figure out the intended element type and may miss errors.  To avoid
+  this problem, put a type annotation on the initialization: `T.let([],
+  T::Array[Foo])` or `T.let({}, T::Hash[Foo,Bar])`.  We currently don't have an
+  automated way to scan for code that is missing these annotations, but at least
+  if you see them, you'll know why they are there.  Related:
+  https://github.com/sorbet/sorbet/issues/3751,
+  https://github.com/sorbet/sorbet/issues/11.
 
 ## Matt's checklist for validating a change to Braid
 

--- a/lib/braid.rb
+++ b/lib/braid.rb
@@ -27,10 +27,7 @@ module Braid
     !!@verbose
   end
 
-  # TODO (typing): One would think `new_value` shouldn't be nilable, but
-  # apparently `lib/braid/main.rb` passes nil sometimes. Is that easy to fix?
-  # (Ditto with `self.force=` below.)
-  sig {params(new_value: T.nilable(T::Boolean)).void}
+  sig {params(new_value: T::Boolean).void}
   def self.verbose=(new_value)
     @verbose = !!new_value
   end
@@ -42,7 +39,7 @@ module Braid
     !!@force
   end
 
-  sig {params(new_value: T.nilable(T::Boolean)).void}
+  sig {params(new_value: T::Boolean).void}
   def self.force=(new_value)
     @force = !!new_value
   end

--- a/lib/braid/commands/remove.rb
+++ b/lib/braid/commands/remove.rb
@@ -1,9 +1,22 @@
-# typed: true
+# typed: strict
 module Braid
   module Commands
     class Remove < Command
-      def run(path, options = {})
-        mirror = config.get!(path)
+      class Options < T::Struct
+        prop :keep, T::Boolean
+      end
+
+      sig {params(path: String, options: Options).void}
+      def initialize(path, options)
+        @path = path
+        @options = options
+      end
+
+      private
+
+      sig {void}
+      def run_internal
+        mirror = config.get!(@path)
 
         with_reset_on_error do
           msg "Removing mirror from '#{mirror.path}'."
@@ -13,7 +26,7 @@ module Braid
           config.remove(mirror)
           add_config_file
 
-          if options[:keep]
+          if @options.keep
             msg "Not removing remote '#{mirror.remote}'" if verbose?
           elsif git.remote_url(mirror.remote)
             msg "Removed remote '#{mirror.path}'" if verbose?

--- a/lib/braid/commands/setup.rb
+++ b/lib/braid/commands/setup.rb
@@ -1,13 +1,20 @@
-# typed: true
+# typed: strict
 module Braid
   module Commands
     class Setup < Command
-      def run(path = nil)
-        path ? setup_one(path) : setup_all
+      sig {params(path: T.nilable(String)).void}
+      def initialize(path = nil)
+        @path = path
       end
 
       private
 
+      sig {void}
+      def run_internal
+        @path ? setup_one(@path) : setup_all
+      end
+
+      sig {void}
       def setup_all
         msg 'Setting up all mirrors.'
         config.mirrors.each do |path|
@@ -15,6 +22,7 @@ module Braid
         end
       end
 
+      sig {params(path: String).void}
       def setup_one(path)
         mirror = config.get!(path)
 
@@ -33,6 +41,7 @@ module Braid
         git.remote_add(mirror.remote, url)
       end
 
+      sig {returns(Config::ConfigMode)}
       def config_mode
         Config::MODE_READ_ONLY
       end

--- a/lib/braid/commands/update.rb
+++ b/lib/braid/commands/update.rb
@@ -1,26 +1,47 @@
-# typed: true
+# typed: strict
 module Braid
   module Commands
     class Update < Command
-      def run(path, options = {})
-        path ? update_one(path, options) : update_all(options)
+      class Options < T::Struct
+        prop :branch, T.nilable(String)
+        prop :tag, T.nilable(String)
+        prop :revision, T.nilable(Operations::Git::ObjectExpr)
+        prop :head, T::Boolean
+        prop :keep, T::Boolean
       end
 
-      protected
+      sig {params(path: T.nilable(String), options: Options).void}
+      def initialize(path, options)
+        @path = path
+        @options = options
+      end
 
-      def update_all(options = {})
-        options.reject! { |k, v| %w(revision head).include?(k) }
+      private
+
+      sig {void}
+      def run_internal
+        @path ? update_one(@path) : update_all
+      end
+
+      sig {void}
+      def update_all
+        # Maintain previous behavior of ignoring these options when updating all
+        # mirrors.  TODO: Should we make it an error if the options were passed?
+        @options.revision = nil
+        @options.head = false
+
         msg 'Updating all mirrors.'
         config.mirrors.each do |path|
           bail_on_local_changes!
-          update_one(path, options)
+          update_one(path)
         end
       end
 
-      def update_one(path, options = {})
+      sig {params(path: String).void}
+      def update_one(path)
         bail_on_local_changes!
 
-        raise BraidError, "Do not specify --head option anymore. Please use '--branch MyBranch' to track a branch or '--tag MyTag' to track a branch" if options['head']
+        raise BraidError, "Do not specify --head option anymore. Please use '--branch MyBranch' to track a branch or '--tag MyTag' to track a branch" if @options.head
 
         mirror           = config.get!(path)
 
@@ -31,16 +52,16 @@ module Braid
         original_branch = mirror.branch
         original_tag = mirror.tag
 
-        raise BraidError, 'Can not update mirror specifying both a revision and a tag' if options['revision'] && options['tag']
-        raise BraidError, 'Can not update mirror specifying both a branch and a tag' if options['branch'] && options['tag']
+        raise BraidError, 'Can not update mirror specifying both a revision and a tag' if @options.revision && @options.tag
+        raise BraidError, 'Can not update mirror specifying both a branch and a tag' if @options.branch && @options.tag
 
-        if options['tag']
-          mirror.tag = options['tag']
+        if @options.tag
+          mirror.tag = @options.tag
           mirror.branch = nil
-        elsif options['branch']
+        elsif @options.branch
           mirror.tag = nil
-          mirror.branch = options['branch']
-        elsif options['revision']
+          mirror.branch = @options.branch
+        elsif @options.revision
           mirror.tag = nil
           mirror.branch = nil
         end
@@ -51,11 +72,14 @@ module Braid
         msg "Fetching new commits for '#{mirror.path}'." if verbose?
         mirror.fetch
 
-        new_revision = options['revision']
+        new_revision = @options.revision
         begin
           new_revision = validate_new_revision(mirror, new_revision)
         rescue InvalidRevision
           # Ignored as it means the revision matches expected
+          # This can only happen if new_revision was non-nil.
+          # TODO (typing): Untangle the logic and remote this `T.must`.
+          new_revision = T.must(new_revision)
         end
 
         from_desc =
@@ -68,19 +92,19 @@ module Braid
           msg "Switching mirror '#{mirror.path}' to branch '#{mirror.branch}' from #{from_desc}."
         elsif mirror.tag && original_tag != mirror.tag
           msg "Switching mirror '#{mirror.path}' to tag '#{mirror.tag}' from #{from_desc}."
-        elsif options['revision'] && original_revision != options['revision']
-          msg "Switching mirror '#{mirror.path}' to revision '#{options['revision']}' from #{from_desc}."
+        elsif @options.revision && original_revision != @options.revision
+          msg "Switching mirror '#{mirror.path}' to revision '#{@options.revision}' from #{from_desc}."
         else
           switching = false
         end
 
         if !switching &&
           (
-            (options['revision'] && was_locked && new_revision == mirror.base_revision) ||
-            (options['revision'].nil? && !was_locked && mirror.merged?(git.rev_parse(new_revision)))
+            (@options.revision && was_locked && new_revision == mirror.base_revision) ||
+            (@options.revision.nil? && !was_locked && mirror.merged?(git.rev_parse(new_revision)))
           )
           msg "Mirror '#{mirror.path}' is already up to date."
-          clear_remote(mirror, options)
+          clear_remote(mirror) unless @options.keep
           return
         end
 
@@ -120,7 +144,7 @@ module Braid
 
         git.commit(commit_message)
         msg "Updated mirror to #{display_revision(mirror)}."
-        clear_remote(mirror, options)
+        clear_remote(mirror) unless @options.keep
       end
     end
   end

--- a/lib/braid/commands/upgrade_config.rb
+++ b/lib/braid/commands/upgrade_config.rb
@@ -1,12 +1,26 @@
-# typed: true
+# typed: strict
 module Braid
   module Commands
     class UpgradeConfig < Command
+      class Options < T::Struct
+        prop :dry_run, T::Boolean
+        prop :allow_breaking_changes, T::Boolean
+      end
+
+      sig {params(options: Options).void}
+      def initialize(options)
+        @options = options
+      end
+
+      private
+
+      sig {returns(Config::ConfigMode)}
       def config_mode
         Config::MODE_UPGRADE
       end
 
-      def run(options)
+      sig {void}
+      def run_internal
         # Config loading in MODE_UPGRADE will bail out only if the config
         # version is too new.
 
@@ -38,11 +52,11 @@ The following breaking changes will occur:
 MSG
         end
 
-        if options['dry_run']
+        if @options.dry_run
           puts <<-MSG
 Run 'braid upgrade-config#{config.breaking_change_descs.empty? ? '' : ' --allow-breaking-changes'}' to perform the upgrade.
 MSG
-        elsif !config.breaking_change_descs.empty? && !options['allow_breaking_changes']
+        elsif !config.breaking_change_descs.empty? && !@options.allow_breaking_changes
           raise BraidError, 'You must pass --allow-breaking-changes to accept the breaking changes.'
         else
           config.write_db

--- a/lib/braid/operations.rb
+++ b/lib/braid/operations.rb
@@ -193,7 +193,9 @@ module Braid
       ObjectID = T.type_alias { String }
 
       # A string containing an expression that can be evaluated to an object ID
-      # by `git rev-parse`.  Ditto the remark about lack of enforcement.
+      # by `git rev-parse`.  This type is enforced even less than `ObjectID` (in
+      # some cases, we apply it directly to user input without validation), but
+      # it still serves to document our intent.
       ObjectExpr = T.type_alias { String } 
 
       # Get the physical path to a file in the git repository (e.g.,

--- a/lib/braid/operations_lite.rb
+++ b/lib/braid/operations_lite.rb
@@ -22,7 +22,7 @@ module Braid
       ).returns(T.type_parameter(:R))
     }
     def self.with_modified_environment(dict, &blk)
-      orig_dict = {}
+      orig_dict = T.let({}, T::Hash[String, T.nilable(String)])
       dict.each { |name, value|
         orig_dict[name] = ENV[name]
         ENV[name] = value

--- a/lib/braid/sorbet/fake_runtime.rb
+++ b/lib/braid/sorbet/fake_runtime.rb
@@ -74,5 +74,24 @@ module Braid
       end
     end
 
+    class Struct
+      def initialize(**kwargs)
+        # The fake runtime isn't obliged to validate the property names or
+        # types.
+        #
+        # Note: If the caller passed a hash of keyword arguments, Ruby will copy
+        # it, so we don't need to copy `kwargs` again here to avoid aliasing.
+        @attrs = kwargs
+      end
+
+      def self.prop(prop_name, prop_type)
+        define_method(prop_name) {
+          @attrs[prop_name]
+        }
+        define_method(prop_name.name + '=') { |new_value|
+          @attrs[prop_name] = new_value
+        }
+      end
+    end
   end
 end

--- a/lib/braid/sorbet/fake_runtime.rb
+++ b/lib/braid/sorbet/fake_runtime.rb
@@ -88,7 +88,7 @@ module Braid
         define_method(prop_name) {
           @attrs[prop_name]
         }
-        define_method(prop_name.name + '=') { |new_value|
+        define_method(:"#{prop_name}=") { |new_value|
           @attrs[prop_name] = new_value
         }
       end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + '/test_helper'
 
 describe 'Braid::Config, when empty' do
   before(:each) do
-    @config = Braid::Config.new({'config_file' => 'tmp.yml'})
+    @config = Braid::Config.new(config_file: 'tmp.yml')
   end
 
   after(:each) do
@@ -23,7 +23,7 @@ end
 
 describe 'Braid::Config, with one mirror' do
   before(:each) do
-    @config = Braid::Config.new({'config_file' => 'tmp.yml'})
+    @config = Braid::Config.new(config_file: 'tmp.yml')
     @mirror = build_mirror
     @config.add(@mirror)
   end

--- a/spec/integration/config_versioning_spec.rb
+++ b/spec/integration/config_versioning_spec.rb
@@ -50,8 +50,19 @@ describe 'Config versioning:' do
           f.write braids_content
         end
 
+        # Test all commands that are supposed to be read-only.  There was
+        # previously a bug in which the config mode for `push` was defined in
+        # the wrong place, leaving `push` to default to MODE_MAY_WRITE.
+
         output = run_command("#{BRAID_BIN} diff skit1")
         expect(output).to eq('')  # no diff
+
+        output = run_command("#{BRAID_BIN} push skit1")
+        expect(output).to match(/No local changes found\. Stopping\./)
+
+        output = run_command("#{BRAID_BIN} setup skit1")
+
+        output = run_command("#{BRAID_BIN} status skit1")
       end
     end
 

--- a/spec/mirror_spec.rb
+++ b/spec/mirror_spec.rb
@@ -7,48 +7,48 @@ describe 'Braid::Mirror.new_from_options' do
   end
 
   it 'should strip trailing slash from specified path' do
-    new_from_options('http://path.git', 'path' => 'vendor/tools/mytool/')
+    new_from_options('http://path.git', Braid::Mirror::Options.new(path: 'vendor/tools/mytool/'))
     expect(@mirror.path).to eq('vendor/tools/mytool')
   end
 
   it 'should define local_ref correctly when explicit branch specified' do
-    new_from_options('http://mytool.git', 'branch' => 'mybranch')
+    new_from_options('http://mytool.git', Braid::Mirror::Options.new(branch: 'mybranch'))
     expect(@mirror.local_ref).to eq('mybranch_braid_mytool/mybranch')
   end
 
   it 'should define local_ref correctly when explicit tag specified' do
-    new_from_options('http://mytool.git', 'tag' => 'v1')
+    new_from_options('http://mytool.git', Braid::Mirror::Options.new(tag: 'v1'))
     expect(@mirror.local_ref).to eq('tags/v1')
   end
 
   it 'should raise an exception if both tag and branch specified' do
     expect {
-      new_from_options('http://mytool.git', 'tag' => 'v1', 'branch' => 'mybranch')
+      new_from_options('http://mytool.git', Braid::Mirror::Options.new(tag: 'v1', branch: 'mybranch'))
     }.to raise_error(Braid::Mirror::NoTagAndBranch)
   end
 
   it 'should define remote_ref correctly when explicit branch specified' do
-    new_from_options('http://mytool.git', 'branch' => 'mybranch')
+    new_from_options('http://mytool.git', Braid::Mirror::Options.new(branch: 'mybranch'))
     expect(@mirror.remote_ref).to eq('+refs/heads/mybranch')
   end
 
   it 'should define remote_ref correctly when explicit tag specified' do
-    new_from_options('http://mytool.git', 'tag' => 'v1')
+    new_from_options('http://mytool.git', Braid::Mirror::Options.new(tag: 'v1'))
     expect(@mirror.remote_ref).to eq('+refs/tags/v1')
   end
 
   it 'should define remote correctly when explicit branch specified' do
-    new_from_options('http://mytool.git', 'branch' => 'mybranch')
+    new_from_options('http://mytool.git', Braid::Mirror::Options.new(branch: 'mybranch'))
     expect(@mirror.remote).to eq('mybranch_braid_mytool')
   end
 
   it 'should define remote correctly when explicit tag specified' do
-    new_from_options('http://mytool.git', 'tag' => 'v1')
+    new_from_options('http://mytool.git', Braid::Mirror::Options.new(tag: 'v1'))
     expect(@mirror.remote).to eq('v1_braid_mytool')
   end
 
   it 'should strip first dot from remote path for dot files and folders' do
-    new_from_options('http://path.git', 'branch' => 'master', 'path' => '.dotfolder/.dotfile.ext')
+    new_from_options('http://path.git', Braid::Mirror::Options.new(branch: 'master', path: '.dotfolder/.dotfile.ext'))
     expect(@mirror.path).to eq('.dotfolder/.dotfile.ext')
     expect(@mirror.remote).to eq('master_braid__dotfolder__dotfile_ext')
   end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -9,7 +9,7 @@ end
 
 require File.dirname(__FILE__) + '/../lib/braid'
 
-def new_from_options(url, options = {})
+def new_from_options(url, options = Braid::Mirror::Options.new)
   @mirror = Braid::Mirror.new_from_options(url, options)
 end
 


### PR DESCRIPTION
This gets most files in `lib` to `typed: strict`.  I also looked briefly at the output of Sorbet's "highlight untyped code" feature and made a few more obvious fixes.

Notable large changes:

- Replace untyped "options" hashes with keyword arguments (for `Config#initialize`) or `T::Struct` subclasses (for `Mirror::new_from_options` and commands).  This required adding barebones support for `T::Struct` to the fake Sorbet runtime.

- Command arguments were passed through `Command::run` as an untyped `*args`.  We want to have different argument types for each command, but we want to continue to share the wrapper code in `Command::run` across all commands.  So have the commands take their arguments in `initialize` instead of `run` and let the caller call `new` on the desired command class directly instead of having `Command::run` do it.

Notable small changes:

- Add `false` default for some command-line options so we can annotate the corresponding variables as non-nilable.

- Now that we don't want `clear_remote` taking an untyped options hash, it seems clearest to just duplicate the `@options.keep` conditional at each caller that has such an option (`Add` doesn't, for whatever reason).

- Remove options from the `Status` command because the CLI never passed them anyway.

- To resolve a type error that showed up in `Mirror::new_from_options` when we annotated the options, clean up `extract_path_from_url` so that it never returns nil.  Take advantage of `String#delete_suffix`, which requires Ruby >= 2.5.0, so bump the minimum Ruby version in the gemspec.  (I haven't tested that everything else works on Ruby 2.5.0; we currently don't have a good process to ensure the minimum is set correctly.)

- Fix `Push#config_mode` that was defined in the wrong place, and add a test.

---

The tests pass on my Linux and Windows systems.