### PR TITLE
Add dependencies for Ruby 3.5 + document a Windows installation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,19 @@ their own systems with whatever is installed.  So breakages may sometimes occur.
 If you run into an environment-related problem, please report it and we'll fix
 it if feasible.  Contributions to improve testing of Braid would be welcome.
 
+### Environment-specific notes
+
+- In our testing on Windows with RubyInstaller as of 2024-11-03, we ran into an
+  issue where running `bundle install` in the Braid repository failed to install
+  the native extension of the `psych` gem.  We found two workarounds that appear
+  to work: (1) use `gem install -g` instead, or (2) run `ridk exec pacman -Syu
+  mingw-w64-ucrt-x86_64-libyaml` to install the missing native library (this may
+  need to be run twice if the first run exits early due to an MSYS2 core system
+  upgrade).  We don't have a good understanding of what's going on here and
+  don't want to spend the time to research it, but we're providing this
+  information in case it helps anyone.  If you know more about this issue,
+  please tell us.
+
 ## Braid version compatibility
 
 Since Braid has been regularly changing the configuration format and adding new

--- a/braid.gemspec
+++ b/braid.gemspec
@@ -37,8 +37,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5.0'
   s.add_dependency(%q<main>, ['>= 4.7.3'])
-  # XXX: Minimum version?
+  # XXX: Minimum versions?
   s.add_dependency(%q<json>)
+  s.add_dependency(%q<pstore>)
+  # Dependencies of `main` that are no longer in the default gems in Ruby 3.5.0.
+  # These should be declared by `main` itself
+  # (https://github.com/ahoward/main/pull/49); we declare them here as a
+  # workaround unless/until that change is released.
+  s.add_dependency(%q<logger>)
+  s.add_dependency(%q<ostruct>)
 
   s.add_development_dependency(%q<rspec>, ['>= 3.4.4'])
   s.add_development_dependency(%q<mocha>, ['>= 0.9.11'])


### PR DESCRIPTION
Braid loads some gems that, starting in Ruby 3.5, will no longer be available unless we declare an explicit dependency on them.  When Bundler is active, Ruby 3.3.5 detects this situation and prints warnings:
```
/home/user/braid/braid-1.wt/lib/braid/config.rb:4: warning: pstore was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add pstore to your Gemfile or gemspec to silence this warning.
/home/user/braid/braid-1.wt/lib/braid/main.rb:14: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
/home/user/.gem/ruby/gems/main-6.3.0/lib/main.rb:80: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```
The warning spew from many Braid subprocesses was starting to annoy me when I ran the integration tests.  So I added the missing dependencies.

The presence of the warnings in Ruby 3.3.5 is [considered a bug](https://bugs.ruby-lang.org/issues/20737) and they will be removed again in Ruby 3.3.6, but they are planned to come back soon enough in Ruby 3.4 (expected around 2024-12-25) that I think it makes sense to go ahead and fix the problem.

The dependencies in question:
- `pstore`, which is loaded directly by Braid
- `logger` and `ostruct`, which are loaded by `main` and really `main`'s responsibility to declare, but with `main` being undermaintained, I doubt that will get fixed any time soon if ever.  I did go ahead and submit [a PR to `main`](https://github.com/ahoward/main/pull/49) so I could at least cite it.

Given the nature of the change, I decided that for my part of the validation, it was sufficient to run the test suite on Linux and Windows but not the extra Sorbet and Git variants listed in `development.md`.  In the process, I ran into an installation issue on Windows that predated this PR (I'm not sure what started it) and decided to document the issue for what it's worth.  @realityforge Please run the tests on macOS, assuming you want to continue supporting macOS.

**Aside:** Should we release a new Braid version?  Releasing this PR would only benefit users who run the released version of Braid under Bundler, which I imagine is pretty uncommon.  The only other unreleased change I know of that affects end users is the fix for #90.  IMO, we are overdue to release #90.  At the time, I may have thought I had other user-visible changes coming soon and would defer the release, but now I think that's unlikely: I'm focused on the type checking, and that's going slowly.  I'm happy to do the release.